### PR TITLE
Patch day Thursday, February 23rd, 2017

### DIFF
--- a/lua/Nostralia/eastern_kingdoms/alterac_mountains/Quest_535_Valik.lua
+++ b/lua/Nostralia/eastern_kingdoms/alterac_mountains/Quest_535_Valik.lua
@@ -1,0 +1,32 @@
+--[[
+ * http://nostralia.org/ True Australian Vanilla World of Warcraft
+ * DESC   : Script for the quest 'Valik' and the NPC 'Henchman Valik'.
+ * UPDATED: 19th Feb 2017
+ * AUTHOR : sundays
+ * NOTE   : Perhaps missing data? 7th March 2016 the quest did not work on
+ *          Nostalrius (watch?v=ZYxAS2sRd2A). Removed from retail in patch
+ *          4.0.3, no relevant wowhead data. Maybe has aggro text?
+--]]
+
+local QuestValik = {};
+
+local QUEST_VALIK = 535;
+local CREATURE_HENCHMAN_VALIK = 2333;
+local FACTION_HOSTILE = 83; -- Changes to this faction on quest completion.
+local FACTION_FRIENDLY = 35;
+
+function QuestValik.OnQuestComplete(event, player, creature, quest, opt)
+    if (quest:GetId() == QUEST_VALIK) then
+        creature:SetFaction(FACTION_HOSTILE);
+        if (player) then
+            creature:AttackStart(player);
+        end
+    end
+end
+
+function QuestValik.OnValikReset(event, creature)
+    creature:SetFaction(FACTION_FRIENDLY);
+end
+
+RegisterCreatureEvent(CREATURE_HENCHMAN_VALIK, 23, QuestValik.OnValikReset);
+RegisterCreatureEvent(CREATURE_HENCHMAN_VALIK, 34, QuestValik.OnQuestComplete);

--- a/lua/Nostralia/eastern_kingdoms/scholomance/instance_scholomance.lua
+++ b/lua/Nostralia/eastern_kingdoms/scholomance/instance_scholomance.lua
@@ -1,0 +1,27 @@
+--[[
+ * http://nostralia.org/ True Australian Vanilla World of Warcraft
+ * DESC   : Contains scripts not already handled in ACID or ScriptDev3.
+ * UPDATED: 22nd Feb 2017
+ * AUTHOR : sundays
+--]]
+
+-- Spectral Projection (summoned by Spectral Tutor)
+-- Partly handled in ScriptDev3.
+local SpectralProjection = {};
+
+local NPC_SPECTRAL_PROJECTION     = 11263;
+local SPELL_IMAGE_PROJECTION_HEAL = 17652;
+
+function SpectralProjection.OnLeaveCombat(event, creature)
+	creature:Kill(creature); -- Don't hang around, happens if Spectral Tutor resets during the Spectral Projection timer.
+end
+
+function SpectralProjection.OnHitBySpell(event, creature, caster, spellid)
+	-- Spectral Tutor is ready to enter in combat again.
+	if (spellid == SPELL_IMAGE_PROJECTION_HEAL) then
+		creature:Kill(creature); -- Despawns on death.
+	end
+end
+
+RegisterCreatureEvent(NPC_SPECTRAL_PROJECTION,  2, SpectralProjection.OnLeaveCombat); -- CREATURE_EVENT_ON_LEAVE_COMBAT
+RegisterCreatureEvent(NPC_SPECTRAL_PROJECTION, 14, SpectralProjection.OnHitBySpell);  -- CREATURE_EVENT_ON_HIT_BY_SPELL

--- a/src/game/Object/Unit.cpp
+++ b/src/game/Object/Unit.cpp
@@ -8813,7 +8813,7 @@ void Unit::SetIncapacitatedState(bool apply, uint32 state, ObjectGuid casterGuid
             if (Unit* victim = getVictim())
             {
                 SetTargetGuid(victim->GetObjectGuid());  // Restore target
-                if (movement)
+                if (movement || (!apply && stun))
                     GetMotionMaster()->MoveChase(victim); // Restore movement generator
             }
             else if (movement)

--- a/src/game/Server/Opcodes.cpp
+++ b/src/game/Server/Opcodes.cpp
@@ -610,12 +610,12 @@ void Opcodes::BuildOpcodeList()
     /*[-ZERO] Need check */ /*0x225*/  StoreOpcode(CMSG_CHAT_IGNORED,                 "CMSG_CHAT_IGNORED",                STATUS_LOGGEDIN,  PROCESS_THREADUNSAFE, &WorldSession::HandleChatIgnoredOpcode);
     /*0x226*/  StoreOpcode(CMSG_GM_VISION,                    "CMSG_GM_VISION",                   STATUS_NEVER,     PROCESS_INPLACE,      &WorldSession::Handle_NULL);
     /*0x227*/  StoreOpcode(CMSG_SERVER_COMMAND,               "CMSG_SERVER_COMMAND",              STATUS_NEVER,     PROCESS_INPLACE,      &WorldSession::Handle_NULL);
-    /*0x228*/  StoreOpcode(CMSG_GM_SILENCE,                   "CMSG_GM_SILENCE",                  STATUS_NEVER,     PROCESS_INPLACE,      &WorldSession::Handle_NULL);
+    /*0x228*/  StoreOpcode(CMSG_GM_SILENCE,                   "CMSG_GM_SILENCE",                  STATUS_LOGGEDIN,     PROCESS_INPLACE,      &WorldSession::GmSilenceHandler);
     /*0x229*/  StoreOpcode(CMSG_GM_REVEALTO,                  "CMSG_GM_REVEALTO",                 STATUS_NEVER,     PROCESS_INPLACE,      &WorldSession::Handle_NULL);
     /*0x22A*/  StoreOpcode(CMSG_GM_RESURRECT,                 "CMSG_GM_RESURRECT",                STATUS_LOGGEDIN,     PROCESS_INPLACE,      &WorldSession::GmResurrectHandler);
     /*0x22B*/  StoreOpcode(CMSG_GM_SUMMONMOB,                 "CMSG_GM_SUMMONMOB",                STATUS_NEVER,     PROCESS_INPLACE,      &WorldSession::Handle_NULL);
     /*0x22C*/  StoreOpcode(CMSG_GM_MOVECORPSE,                "CMSG_GM_MOVECORPSE",               STATUS_NEVER,     PROCESS_INPLACE,      &WorldSession::Handle_NULL);
-    /*0x22D*/  StoreOpcode(CMSG_GM_FREEZE,                    "CMSG_GM_FREEZE",                   STATUS_NEVER,     PROCESS_INPLACE,      &WorldSession::Handle_NULL);
+    /*0x22D*/  StoreOpcode(CMSG_GM_FREEZE,                    "CMSG_GM_FREEZE",                   STATUS_LOGGEDIN,     PROCESS_INPLACE,      &WorldSession::GmFreezeHandler);
     /*0x22E*/  StoreOpcode(CMSG_GM_UBERINVIS,                 "CMSG_GM_UBERINVIS",                STATUS_NEVER,     PROCESS_INPLACE,      &WorldSession::Handle_NULL);
     /*0x22F*/  StoreOpcode(CMSG_GM_REQUEST_PLAYER_INFO,       "CMSG_GM_REQUEST_PLAYER_INFO",      STATUS_NEVER,     PROCESS_INPLACE,      &WorldSession::Handle_NULL);
     /*0x230*/  StoreOpcode(SMSG_GM_PLAYER_INFO,               "SMSG_GM_PLAYER_INFO",              STATUS_NEVER,     PROCESS_INPLACE,      &WorldSession::Handle_NULL);

--- a/src/game/Server/Opcodes.h
+++ b/src/game/Server/Opcodes.h
@@ -958,6 +958,7 @@ enum OpcodesList
     CMSG_ACCEPT_LEVEL_GRANT                         = 0x41F,
     SMSG_REFER_A_FRIEND_FAILURE                     = 0x420,
     SMSG_SUMMON_CANCEL                              = 0x423,
+	SMSG_GM_SILENCE = 0x51F,
 	CMSG_GM_BUG = 0x520,
 	CMSG_QUEST_IQC = 0x521,
 	SMSG_QUEST_IQC_RESPONSE = 0x522,

--- a/src/game/Server/WorldSession.h
+++ b/src/game/Server/WorldSession.h
@@ -731,6 +731,8 @@ class WorldSession
 		void WhoIsHandler(WorldPacket &msg);
 		void HandleTeleportToUnit(WorldPacket &msg);
 		void GmResurrectHandler(WorldPacket &msg);
+        void GmFreezeHandler(WorldPacket &msg);
+        void GmSilenceHandler(WorldPacket &msg);
 
 #ifdef ENABLE_PLAYERBOTS
         void HandleBotPackets();

--- a/src/game/WorldHandlers/ClientCommands.cpp
+++ b/src/game/WorldHandlers/ClientCommands.cpp
@@ -264,3 +264,84 @@ void WorldSession::GmResurrectHandler(WorldPacket &msg)
 	else
 		SendNotification(LANG_YOU_NOT_HAVE_PERMISSION);
 }
+
+void WorldSession::GmFreezeHandler(WorldPacket &msg)
+{
+    Player *plyr;
+    char name[64];
+    int result;
+
+    plyr = 0;
+    *name = 0;
+    result = 0;
+    if (GetSecurity() > 1)
+    {
+        msg >> name;
+        NormalizePlayerName(name);
+        if (plyr = sObjectAccessor.FindPlayerByName(name))
+        {
+            if (plyr->HasAura(9454)) // GM Freeze.
+            {
+                result = 2;
+                plyr->RemoveAura(9454, EFFECT_INDEX_0, 0);
+            }
+            else
+            {
+                if (plyr->IsAlive())
+                {
+                    plyr->CastSpell(plyr, 9454, false, 0);
+                    result = 1;
+                }
+            }
+            msg.clear();
+            msg.SetOpcode(SMSG_GM_FREEZE);
+            msg << result;
+            SendPacket(&msg);
+        }
+        else
+            SendPlayerNotFoundFailure();
+    }
+    else
+        SendNotification(LANG_YOU_NOT_HAVE_PERMISSION);
+}
+
+// @TODO: Only the visual is implemented for this.
+void WorldSession::GmSilenceHandler(WorldPacket &msg)
+{
+    Player *plyr;
+    char name[64];
+    int result;
+
+    plyr = 0;
+    *name = 0;
+    result = 0;
+    if (GetSecurity() > 1)
+    {
+        msg >> name;
+        NormalizePlayerName(name);
+        if (plyr = sObjectAccessor.FindPlayerByName(name))
+        {
+            if (plyr->HasAura(1852)) // GM Silence (visual).
+            {
+                result = 2;
+                plyr->RemoveAura(1852, EFFECT_INDEX_0, 0);
+            }
+            else
+            {
+                if (plyr->IsAlive()) // Should affect while dead too? (Prevents chat with normal players).
+                {
+                    plyr->CastSpell(plyr, 1852, false, 0);
+                    result = 1;
+                }
+            }
+            msg.clear();
+            msg.SetOpcode(SMSG_GM_SILENCE);
+            msg << result;
+            SendPacket(&msg);
+        }
+        else
+            SendPlayerNotFoundFailure();
+    }
+    else
+        SendNotification(LANG_YOU_NOT_HAVE_PERMISSION);
+}

--- a/src/modules/SD3/include/sc_gossip.h
+++ b/src/modules/SD3/include/sc_gossip.h
@@ -174,6 +174,8 @@ extern uint32 GetSkillLevel(Player* pPlayer, uint32 uiSkill);
 
 // Closes the Menu
 #define CLOSE_GOSSIP_MENU()        PlayerTalkClass->CloseGossip()
+// Clears the menu.
+#define CLEAR_GOSSIP_MENU()        PlayerTalkClass->ClearMenus()
 
 // Fuctions to send NPC lists
 // a - is always the npc guid (ObjectGuid)

--- a/src/modules/SD3/scripts/eastern_kingdoms/blackrock_mountain/blackrock_depths/blackrock_depths.cpp
+++ b/src/modules/SD3/scripts/eastern_kingdoms/blackrock_mountain/blackrock_depths/blackrock_depths.cpp
@@ -644,8 +644,11 @@ struct npc_phalanxAI : public npc_escortAI
         // so we made him restart right before reaching the door to guard it (again)
         if (HasEscortState(STATE_ESCORT_ESCORTING) || HasEscortState(STATE_ESCORT_PAUSED))
         {
-            SetCurrentWaypoint(1);
-            SetEscortPaused(false);
+            // SetCurrentWaypoint(1); // Causes crash.
+            m_creature->GetMotionMaster()->MoveIdle();
+            m_creature->NearTeleportTo(868.122, -223.884, -43.695, m_fKeepDoorOrientation);
+            m_creature->SendHeartBeat();
+            // MovementGenerator should be reset?
         }
 
         m_fKeepDoorOrientation = 2.06059f;
@@ -1859,6 +1862,10 @@ struct boss_plugger_spazzringAI : public ScriptedAI
             // Activate Phalanx and handle patrons faction
             if (Creature* pPhalanx = m_pInstance->GetSingleCreatureFromStorage(NPC_PHALANX))
             {
+                // Phalanx is already active if Rocknot's event is done.
+                if (m_pInstance->GetData(TYPE_ROCKNOT) == DONE)
+                    return;
+
                 if (npc_phalanxAI* pEscortAI = dynamic_cast<npc_phalanxAI*>(pPhalanx->AI()))
                     pEscortAI->Start(false, NULL, NULL, true);
             }

--- a/src/modules/SD3/scripts/eastern_kingdoms/blackrock_mountain/blackrock_depths/blackrock_depths.cpp
+++ b/src/modules/SD3/scripts/eastern_kingdoms/blackrock_mountain/blackrock_depths/blackrock_depths.cpp
@@ -640,7 +640,7 @@ struct npc_phalanxAI : public npc_escortAI
 
     void Reset() override
     {
-        // If reset after an fight, it means Phalanx has already started moving (if not already reached door)
+        // If reset after a fight, it means Phalanx has already started moving (if not already reached door)
         // so we made him restart right before reaching the door to guard it (again)
         if (HasEscortState(STATE_ESCORT_ESCORTING) || HasEscortState(STATE_ESCORT_PAUSED))
         {
@@ -671,6 +671,8 @@ struct npc_phalanxAI : public npc_escortAI
         {
             case 0:
                 DoScriptText(YELL_PHALANX_AGGRO, m_creature);
+                m_creature->SetFactionTemporary(FACTION_DARK_IRON, TEMPFACTION_NONE);
+                SetRun(true);
                 break;
             case 1:
                 SetEscortPaused(true);
@@ -789,6 +791,7 @@ struct npc_mistress_nagmaraAI : public ScriptedAI
 
     ScriptedInstance* m_pInstance;
     Creature* pRocknot;
+    CreatureAI *pRocknotAI;
 
     uint8 m_uiPhase;
     uint32 m_uiPhaseTimer;
@@ -891,12 +894,16 @@ struct npc_mistress_nagmara : public CreatureScript
     
     bool OnGossipHello(Player* pPlayer, Creature* pCreature) override
     {
+        ScriptedInstance* pInstance = (ScriptedInstance*)pCreature->GetInstanceData();
         if (pCreature->IsQuestGiver())
             pPlayer->PrepareQuestMenu(pCreature->GetObjectGuid());
 
+        pPlayer->CLEAR_GOSSIP_MENU();
         if (pPlayer->GetQuestStatus(QUEST_POTION_LOVE) == QUEST_STATUS_COMPLETE)
         {
-            pPlayer->ADD_GOSSIP_ITEM_ID(GOSSIP_ICON_CHAT, GOSSIP_ITEM_NAGMARA, GOSSIP_SENDER_MAIN, GOSSIP_ACTION_INFO_DEF + 1);
+            if (pInstance->GetData(TYPE_ROCKNOT) != SPECIAL && pInstance->GetData(TYPE_ROCKNOT) != DONE)
+                pPlayer->ADD_GOSSIP_ITEM_ID(GOSSIP_ICON_CHAT, GOSSIP_ITEM_NAGMARA, GOSSIP_SENDER_MAIN, GOSSIP_ACTION_INFO_DEF + 1);
+
             pPlayer->SEND_GOSSIP_MENU(GOSSIP_ID_NAGMARA_2, pCreature->GetObjectGuid());
         }
         else
@@ -942,6 +949,10 @@ struct npc_mistress_nagmara : public CreatureScript
 enum
 {
     SAY_GOT_BEER       = -1230000,
+    SAY_MORE_BEER      = -1230036,
+    SAY_BARREL_1       = -1230044,
+    SAY_BARREL_2       = -1230045,
+    SAY_BARREL_3       = -1230046,
 
     SPELL_DRUNKEN_RAGE = 14872,
 
@@ -964,6 +975,10 @@ struct npc_rocknot : public CreatureScript
 
         uint32 m_uiBreakKegTimer;
         uint32 m_uiBreakDoorTimer;
+        uint32 m_uiEmoteTimer;
+        uint32 m_uiBarReactTimer;
+        float m_fInitialOrientation;
+        Creature *pNagmara;
 
         void Reset() override
         {
@@ -974,6 +989,10 @@ struct npc_rocknot : public CreatureScript
 
             m_uiBreakKegTimer = 0;
             m_uiBreakDoorTimer = 0;
+            m_uiEmoteTimer = 0;
+            m_uiBarReactTimer = 0;
+            m_fInitialOrientation = 3.21141f;
+            pNagmara = m_pInstance->GetSingleCreatureFromStorage(NPC_MISTRESS_NAGMARA);
         }
 
         void DoGo(uint32 id, uint32 state)
@@ -993,21 +1012,66 @@ struct npc_rocknot : public CreatureScript
 
             switch (uiPointId)
             {
+            case 0: // Beer quest path.
+                SetEscortPaused(true);
+                if (m_pInstance->GetData(TYPE_NAGMARA) == IN_PROGRESS)
+                {
+                    pNagmara->GetMotionMaster()->MoveFollow(m_creature, 2.0f, 0);
+                    SetCurrentWaypoint(7); // Bad logic, gets incremented by 1.
+                }
+                SetEscortPaused(false);
+                break;
             case 1:
                 m_creature->HandleEmote(EMOTE_ONESHOT_KICK);
                 break;
             case 2:
                 m_creature->HandleEmote(EMOTE_ONESHOT_ATTACKUNARMED);
+                DoScriptText(SAY_BARREL_1, m_creature);
                 break;
             case 3:
                 m_creature->HandleEmote(EMOTE_ONESHOT_ATTACKUNARMED);
                 break;
             case 4:
                 m_creature->HandleEmote(EMOTE_ONESHOT_KICK);
+                DoScriptText(SAY_BARREL_2, m_creature);
                 break;
             case 5:
-                m_creature->HandleEmote(EMOTE_ONESHOT_KICK);
                 m_uiBreakKegTimer = 2000;
+                break;
+            case 7: // Home after breaking keg.
+                SetEscortPaused(true);
+                m_creature->SetFacingTo(m_fInitialOrientation);
+                break;
+            case 8: // Nagmara's Love Potion waypoint path.
+                // Nagmara follows us.
+                if (!pNagmara)
+                {
+                    SetEscortPaused(true);
+                    SetCurrentWaypoint(6); // Gets incremented by 1 after break.
+                }
+                else
+                    pNagmara->GetMotionMaster()->MoveFollow(m_creature, 2.0f, 0);
+                break;
+            case 15:
+                // Open back door.
+                if (GameObject *pBackDoor = m_pInstance->GetSingleGameObjectFromStorage(GO_BAR_DOOR))
+                    pBackDoor->SetGoState(GO_STATE_ACTIVE);
+
+                if (pNagmara)
+                    pNagmara->GetMotionMaster()->MoveFollow(m_creature, 2.0f, 0);
+                break;
+            case 32:
+                if (!pNagmara)
+                    break;
+
+                pNagmara->GetMotionMaster()->MoveIdle();
+                pNagmara->GetMotionMaster()->MovePoint(0, 878.1779f, -222.0662f, -49.96714f);
+                if (npc_mistress_nagmaraAI* pNagmaraAI = dynamic_cast<npc_mistress_nagmaraAI*>(pNagmara->AI()))
+                {
+                    pNagmaraAI->m_uiPhase = 4;
+                    pNagmaraAI->m_uiPhaseTimer = 5000;
+                }
+                SetEscortPaused(true);
                 break;
             }
         }
@@ -1019,18 +1083,25 @@ struct npc_rocknot : public CreatureScript
                 return;
             }
 
+            // Begin Nagmara escort.
+            if (m_pInstance->GetData(TYPE_NAGMARA) == SPECIAL)
+            {
+                m_pInstance->SetData(TYPE_NAGMARA, IN_PROGRESS);
+                Start(false, NULL, NULL, true);
+                return;
+            }
+
             if (m_uiBreakKegTimer)
             {
                 if (m_uiBreakKegTimer <= uiDiff)
                 {
                     DoGo(GO_BAR_KEG_SHOT, 0);
-                    m_uiBreakKegTimer = 0;
                     m_uiBreakDoorTimer = 1000;
+                    m_uiBarReactTimer = 5000;
+                    m_uiBreakKegTimer = 0;
                 }
                 else
-                {
                     m_uiBreakKegTimer -= uiDiff;
-                }
             }
 
             if (m_uiBreakDoorTimer)
@@ -1038,24 +1109,53 @@ struct npc_rocknot : public CreatureScript
                 if (m_uiBreakDoorTimer <= uiDiff)
                 {
                     DoGo(GO_BAR_DOOR, 2);
+                    m_creature->HandleEmote(EMOTE_ONESHOT_KICK);
+                    DoScriptText(SAY_BARREL_3, m_creature);
                     DoGo(GO_BAR_KEG_TRAP, 0);                   // doesn't work very well, leaving code here for future
-                    // spell by trap has effect61, this indicate the bar go hostile
+                    // spell by trap has effect61
 
-                    if (Creature* pTmp = m_pInstance->GetSingleCreatureFromStorage(NPC_PHALANX))
-                    {
-                        pTmp->SetFactionTemporary(14, TEMPFACTION_NONE);
-                    }
-
-                    // for later, this event(s) has alot more to it.
-                    // optionally, DONE can trigger bar to go hostile.
-                    m_pInstance->SetData(TYPE_BAR, DONE);
+                    // DONE triggers patrons to go hostile.
+                    m_pInstance->SetData(TYPE_ROCKNOT, DONE);
 
                     m_uiBreakDoorTimer = 0;
                 }
                 else
-                {
                     m_uiBreakDoorTimer -= uiDiff;
+            }
+
+            if (m_uiEmoteTimer)
+            {
+                if (m_uiEmoteTimer <= uiDiff)
+                {
+                    if (m_pInstance->GetData(TYPE_ROCKNOT) == SPECIAL)
+                    {
+                        DoCastSpellIfCan(m_creature, SPELL_DRUNKEN_RAGE);
+                        DoScriptText(SAY_MORE_BEER, m_creature);      // Begin walking to barrel.
+                        Start(false);
+                    }
+                    else
+                        m_creature->HandleEmote(EMOTE_ONESHOT_CHEER); // Still accepting beer.
+
+                    m_uiEmoteTimer = 0;
                 }
+                else
+                    m_uiEmoteTimer -= uiDiff;
+            }
+
+            if (m_uiBarReactTimer)
+            {
+                if (m_uiBarReactTimer <= uiDiff)
+                {
+                    if (Creature* pPhalanx = m_pInstance->GetSingleCreatureFromStorage(NPC_PHALANX))
+                    {
+                        if (npc_phalanxAI* pEscortAI = dynamic_cast<npc_phalanxAI*>(pPhalanx->AI()))
+                            pEscortAI->Start(false, NULL, NULL, true);
+                    }
+
+                    m_uiBarReactTimer = 0;
+                }
+                else
+                    m_uiBarReactTimer -= uiDiff;
             }
         }
     };
@@ -1065,40 +1165,29 @@ struct npc_rocknot : public CreatureScript
         return new npc_rocknotAI(pCreature);
     }
 
-    bool OnQuestRewarded(Player* /*pPlayer*/, Creature* pCreature, Quest const* pQuest) override
+    bool OnQuestRewarded(Player* pPlayer, Creature* pCreature, Quest const* pQuest) override
     {
         ScriptedInstance* pInstance = (ScriptedInstance*)pCreature->GetInstanceData();
 
         if (!pInstance)
-        {
             return true;
-        }
 
-        if (pInstance->GetData(TYPE_BAR) == DONE || pInstance->GetData(TYPE_BAR) == SPECIAL)
-        {
+        if (pInstance->GetData(TYPE_ROCKNOT) == DONE || pInstance->GetData(TYPE_ROCKNOT) == SPECIAL)
             return true;
-        }
 
         if (pQuest->GetQuestId() == QUEST_ALE)
         {
-            if (pInstance->GetData(TYPE_BAR) != IN_PROGRESS)
-            {
-                pInstance->SetData(TYPE_BAR, IN_PROGRESS);
-            }
+            if (pInstance->GetData(TYPE_ROCKNOT) != IN_PROGRESS)
+                pInstance->SetData(TYPE_ROCKNOT, IN_PROGRESS);
 
-            pInstance->SetData(TYPE_BAR, SPECIAL);
+            if (pPlayer)
+                pCreature->SetFacingToObject(pPlayer);
 
-            // keep track of amount in instance script, returns SPECIAL if amount ok and event in progress
-            if (pInstance->GetData(TYPE_BAR) == SPECIAL)
-            {
-                DoScriptText(SAY_GOT_BEER, pCreature);
-                pCreature->CastSpell(pCreature, SPELL_DRUNKEN_RAGE, false);
+            DoScriptText(SAY_GOT_BEER, pCreature); // Blizzlike to say it the 3rd time (Source: http://wowwiki.wikia.com/wiki/Grim_Guzzler)
+            if (npc_rocknotAI *pEscortAI = dynamic_cast<npc_rocknotAI*>(pCreature->AI()))
+                pEscortAI->m_uiEmoteTimer = 1500;
 
-                if (npc_rocknotAI* pEscortAI = dynamic_cast<npc_rocknotAI*>(pCreature->AI()))
-                {
-                    pEscortAI->Start(false, NULL, NULL, true);
-                }
-            }
+            pInstance->SetData(TYPE_ROCKNOT, SPECIAL); // Increments beer counter by 1.
         }
 
         return true;

--- a/src/modules/SD3/scripts/eastern_kingdoms/blackrock_mountain/blackrock_depths/instance_blackrock_depths.cpp
+++ b/src/modules/SD3/scripts/eastern_kingdoms/blackrock_mountain/blackrock_depths/instance_blackrock_depths.cpp
@@ -654,9 +654,12 @@ void instance_blackrock_depths::HandleBarPatrons(uint8 uiEventType)
             {
                 if (Creature* pPatron = instance->GetCreature(*itr))
                 {
+                    float fX, fY, fZ;
+                    pPatron->GetRespawnCoord(fX, fY, fZ);
                     pPatron->SetFactionTemporary(FACTION_DARK_IRON, TEMPFACTION_RESTORE_RESPAWN);
                     pPatron->SetStandState(UNIT_STAND_STATE_STAND);
-                    // Patron should also start random movement around their current position (= home)
+                    pPatron->GetMotionMaster()->MoveRandomAroundPoint(fX, fY, fZ, 5.0f); // Patron should also start random movement around their current position (= home)
+                    pPatron->HandleEmoteState(0); // Stop dancing. (Blizzlike?)
                 }
             }
             // Mistress Nagmara and Private Rocknot despawn if the bar turns hostile

--- a/src/modules/SD3/scripts/eastern_kingdoms/scholomance/scholomance.cpp
+++ b/src/modules/SD3/scripts/eastern_kingdoms/scholomance/scholomance.cpp
@@ -70,15 +70,24 @@ struct npc_spectral_tutor : public CreatureScript
             m_uiProjectionTimer = urand(12000, 13000);
         }
 
+        void EnterEvadeMode() override
+        {
+            if (m_uiProjEndTimer)
+                return;
+        }
+
         void UpdateAI(const uint32 uiDiff) override
         {
             if (!m_creature->SelectHostileTarget() || !m_creature->getVictim())
                 return;
+            
 
             if (m_uiProjEndTimer)
             {
                 if (m_uiProjEndTimer <= uiDiff)
                 {
+                    // Despawn handled in Lua.
+                    // Health leech doesn't work!
                     if (DoCastSpellIfCan(m_creature, SPELL_IMAGE_PROJECTION_HEAL) == CAST_OK)
                         m_uiProjEndTimer = 0;
                 }
@@ -110,7 +119,7 @@ struct npc_spectral_tutor : public CreatureScript
                 if (DoCastSpellIfCan(m_creature, SPELL_IMAGE_PROJECTION) == CAST_OK)
                 {
                     DoCastSpellIfCan(m_creature, SPELL_IMAGE_PROJECTION_SUMMON, CAST_TRIGGERED);
-                    m_uiProjEndTimer = 1000;
+                    m_uiProjEndTimer = 1000; // In case you were wondering, the timer stops ticking while the creature is invisible (due to the spell, which lasts 5s).
                     m_uiProjectionTimer = urand(18000, 25000);
                 }
             }

--- a/src/modules/SD3/scripts/eastern_kingdoms/sunken_temple/instance_sunken_temple.cpp
+++ b/src/modules/SD3/scripts/eastern_kingdoms/sunken_temple/instance_sunken_temple.cpp
@@ -44,6 +44,7 @@ struct is_sunken_temple : public InstanceScript
     {
     public:
         instance_sunken_temple(Map* pMap) : ScriptedInstance(pMap),
+            m_uiEranikusDefendersRemaining(0),
             m_uiProtectorsRemaining(0),
             m_uiStatueCounter(0),
             m_uiFlameCounter(0),
@@ -109,10 +110,15 @@ struct is_sunken_temple : public InstanceScript
             case NPC_MIJAN:
                 ++m_uiProtectorsRemaining;
                 break;
+            case NPC_HAZZAS:
+            case NPC_MORPHAZ:
+                ++m_uiEranikusDefendersRemaining;
+                break;
             case NPC_JAMMALAN:
             case NPC_ATALARION:
             case NPC_SHADE_OF_HAKKAR:
             case NPC_AVATAR_OF_HAKKAR:
+            case NPC_SHADE_OF_ERANIKUS:
                 m_mNpcEntryGuidStore[pCreature->GetEntry()] = pCreature->GetObjectGuid();
                 break;
             }
@@ -150,6 +156,12 @@ struct is_sunken_temple : public InstanceScript
                 m_bCanSummonBloodkeeper = true;
                 break;
 
+                // Hazzas and Morphaz
+            case NPC_HAZZAS:
+            case NPC_MORPHAZ:
+                SetData(TYPE_ERANIKUS_DEFENDER, DONE);
+                break;
+
                 // Jammalain mini-bosses
             case NPC_ZOLO:
             case NPC_GASHER:
@@ -183,6 +195,22 @@ struct is_sunken_temple : public InstanceScript
                         DoUseDoorOrButton(GO_JAMMALAN_BARRIER);
                         // Intro yell
                         DoOrSimulateScriptTextForThisInstance(SAY_JAMMALAN_INTRO, NPC_JAMMALAN);
+                    }
+                }
+                break;
+            case TYPE_ERANIKUS_DEFENDER:
+                if (uiData == DONE)
+                {
+                    --m_uiEranikusDefendersRemaining;
+
+                    if (m_uiEranikusDefendersRemaining == 0)
+                    {
+                        Creature *pEranikus = GetSingleCreatureFromStorage(NPC_SHADE_OF_ERANIKUS);
+                        if (pEranikus)
+                        {
+                            // Eranikus encounter can now start.
+                            pEranikus->RemoveFlag(UNIT_FIELD_FLAGS, UNIT_FLAG_NOT_ATTACKABLE_1); // Remove unattackable flag
+                        }
                     }
                 }
                 break;
@@ -552,6 +580,7 @@ struct is_sunken_temple : public InstanceScript
         uint32 m_auiEncounter[MAX_ENCOUNTER];
         std::string m_strInstData;
 
+        uint8 m_uiEranikusDefendersRemaining;               // Hazzas and Morphaz counter.
         uint8 m_uiProtectorsRemaining;                      // Jammalan door handling
         uint8 m_uiStatueCounter;                            // Atalarion Statue Event
         uint8 m_uiFlameCounter;                             // Avatar of Hakkar Event

--- a/src/modules/SD3/scripts/eastern_kingdoms/sunken_temple/instance_sunken_temple.cpp
+++ b/src/modules/SD3/scripts/eastern_kingdoms/sunken_temple/instance_sunken_temple.cpp
@@ -315,6 +315,18 @@ struct is_sunken_temple : public InstanceScript
 
                 m_strInstData = saveStream.str();
 
+                // Open gates to Sanctum of the Fallen God.
+                GameObject *pDoor1 = GetSingleGameObjectFromStorage(GO_HAKKAR_DOOR_1);
+                GameObject *pDoor2 = GetSingleGameObjectFromStorage(GO_HAKKAR_DOOR_2);
+                
+                // I'd rather set the state directly instead of toggling them, since I couldn't test with a full group.
+                // Better to be sure than sorry after you've locked a group of 5 people in a room unintentionally.
+                if (pDoor1 && pDoor2)
+                {
+                    pDoor1->SetGoState(GO_STATE_ACTIVE);
+                    pDoor2->SetGoState(GO_STATE_ACTIVE);
+                }
+
                 SaveToDB();
                 OUT_SAVE_INST_DATA_COMPLETE;
             }

--- a/src/modules/SD3/scripts/eastern_kingdoms/sunken_temple/sunken_temple.h
+++ b/src/modules/SD3/scripts/eastern_kingdoms/sunken_temple/sunken_temple.h
@@ -29,7 +29,7 @@
 
 enum
 {
-    MAX_ENCOUNTER         = 5,
+    MAX_ENCOUNTER         = 6,
     TYPE_SIGNAL = MAX_ENCOUNTER,
     MAX_STATUES           = 6,
     MAX_FLAMES            = 4,
@@ -39,6 +39,10 @@ enum
     TYPE_JAMMALAN         = 2,
     TYPE_MALFURION        = 3,
     TYPE_AVATAR           = 4,
+    TYPE_ERANIKUS_DEFENDER = 5,
+
+    NPC_HAZZAS            = 5722,
+    NPC_MORPHAZ           = 5719,
 
     NPC_ATALARION         = 8580,
     NPC_DREAMSCYTH        = 5721,


### PR DESCRIPTION
# Patch 1.3

## **Regarding a49cc03**
When [Intimidating Shout](http://db.vanillagaming.org/?spell=5246) affects more than one target, your selected target will be rooted (stunned!) in place as well as feared.

The fear expires first, causing movement to be reset. When the stun expires, MovementGenerator does not set MoveChase to the creature's victim (player). This results in them defaulting to MoveIdle state, while still being in combat with the player and still attacking him/her.

This fix may or may not break other stuns with corner cases where the victim should not be chased.

It is worth noting that it's possible the rooted/stunned creature should not also be feared. We should check videos to see if two buffs (one fear, one stun) appear on the creature. This would fix the bug with movement being expired.